### PR TITLE
Do not select extrafiles like ThemeSongs

### DIFF
--- a/jellyfinfav2m3u
+++ b/jellyfinfav2m3u
@@ -48,7 +48,7 @@ for row in cur.execute('SELECT userId,key FROM UserDatas WHERE isFavorite=1'):
 for userid in favourites:
     print('Favourites for userid='+str(userid))
     entries = list()
-    query='SELECT Path FROM TypedBaseItems WHERE type="MediaBrowser.Controller.Entities.Audio.Audio" AND UserDataKey=?'
+    query='SELECT Path FROM TypedBaseItems WHERE type="MediaBrowser.Controller.Entities.Audio.Audio" AND ExtraType IS NULL AND UserDataKey=?'
     for userdatakey in favourites[userid]:
         for entry in cur.execute(query, [userdatakey]):
             entries.append(entry[0])


### PR DESCRIPTION
Added check if an audio file is not an extrafile.
It is possible that two files have the same UserDataKey. For me it happened because I use an audio file as the theme for a movie and also have a same file in the soundtrack in my music library. Items from a music library should always have no extratype(NULL), while themes have the type "ThemeSong".